### PR TITLE
Remove deprecated Linters

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -260,11 +260,6 @@ linters:
         packages:
           - title: linter-rust
             url: https://atom.io/packages/linter-rust
-      - title: Elixir
-        modal: elixir
-        packages:
-          - title: linter-elixirc
-            url: https://atom.io/packages/linter-elixirc
       - title: Erlang
         modal: erlang
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -63,11 +63,6 @@ linters:
         packages:
           - title: linter-tslint
             url: https://atom.io/packages/linter-tslint
-      - title: Dart
-        modal: dart
-        packages:
-          - title: linter-dartanalyzer
-            url: https://atom.io/packages/linter-dartanalyzer
       - title: LiveScript
         modal: ls
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -229,11 +229,6 @@ linters:
         packages:
           - title: linter-bootlint
             url: https://atom.io/packages/linter-bootlint
-      - title: Squirrel
-        modal: squirrel
-        packages:
-          - title: linter-squirrel
-            url: https://atom.io/packages/linter-squirrel
       - title: harbour
         modal: harbour
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -75,11 +75,6 @@ linters:
         packages:
           - title: linter-haml
             url: https://atom.io/packages/linter-haml
-      - title: Slim
-        modal: slim
-        packages:
-          - title: linter-slim
-            url: https://atom.io/packages/linter-slim
       - title: PHP
         modal: php
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -42,11 +42,6 @@ linters:
             url: https://atom.io/packages/linter-marlint
           - title: linter-liferay
             url: https://atom.io/packages/linter-liferay
-      - title: React.JS
-        modal: jsx
-        packages:
-          - title: linter-jsxhint
-            url: https://atom.io/packages/linter-jsxhint
       - title: CoffeeScript
         modal: coffee
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -295,8 +295,6 @@ linters:
       - title: Go
         modal: go
         packages:
-          - title: linter-govet
-            url: https://atom.io/packages/linter-govet
           - title: linter-golinter
             url: https://atom.io/packages/linter-golinter
       - title: JSON

--- a/_config.yml
+++ b/_config.yml
@@ -132,9 +132,7 @@ linters:
         modal: stylus
         packages:
           - title: linter-stylint
-            url: https://atom.io/packages/linter-stylus
-          - title: linter-stylus
-            url: https://atom.io/packages/linter-stylus
+            url: https://atom.io/packages/linter-stylint
       - title: Bash
         modal: sh
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -265,16 +265,6 @@ linters:
         packages:
           - title: linter-erlang
             url: https://atom.io/packages/linter-erlang
-      - title: JSONiq
-        modal: jsoniq
-        packages:
-          - title: linter-jsoniq
-            url: https://atom.io/packages/linter-jsoniq
-      - title: XQuery
-        modal: xquery
-        packages:
-          - title: linter-jsoniq
-            url: https://atom.io/packages/linter-jsoniq
       - title: Swift
         modal: swift
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -224,11 +224,6 @@ linters:
         packages:
           - title: linter-bootlint
             url: https://atom.io/packages/linter-bootlint
-      - title: harbour
-        modal: harbour
-        packages:
-          - title: linter-harbour
-            url: https://atom.io/packages/linter-harbour
       - title: Rust
         modal: rust
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -99,8 +99,6 @@ linters:
         packages:
           - title: linter-pylint
             url: https://atom.io/packages/linter-pylint
-          - title: linter-pyflakes
-            url: https://atom.io/packages/linter-pyflakes
           - title: linter-pep8
             url: https://atom.io/packages/linter-pep8
           - title: linter-pep257

--- a/_config.yml
+++ b/_config.yml
@@ -263,8 +263,6 @@ linters:
       - title: Erlang
         modal: erlang
         packages:
-          - title: linter-erlc
-            url: https://atom.io/packages/linter-erlc
           - title: linter-erlang
             url: https://atom.io/packages/linter-erlang
       - title: JSONiq

--- a/_config.yml
+++ b/_config.yml
@@ -135,11 +135,6 @@ linters:
             url: https://atom.io/packages/linter-stylus
           - title: linter-stylus
             url: https://atom.io/packages/linter-stylus
-      - title: XML
-        modal: xml
-        packages:
-          - title: linter-xmllint
-            url: https://atom.io/packages/linter-xmllint
       - title: Bash
         modal: sh
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -32,8 +32,6 @@ linters:
             url: https://atom.io/packages/linter-jscs
           - title: linter-eslint
             url: https://atom.io/packages/linter-eslint
-          - title: linter-gjslint
-            url: https://atom.io/packages/linter-gjslint
           - title: linter-flow
             url: https://atom.io/packages/linter-flow
           - title: linter-flow-plus

--- a/_config.yml
+++ b/_config.yml
@@ -295,8 +295,6 @@ linters:
       - title: Go
         modal: go
         packages:
-          - title: linter-gotype
-            url: https://atom.io/packages/linter-gotype
           - title: linter-govet
             url: https://atom.io/packages/linter-govet
           - title: linter-golinter

--- a/_config.yml
+++ b/_config.yml
@@ -299,26 +299,6 @@ linters:
         packages:
           - title: linter-jsoniq
             url: https://atom.io/packages/linter-jsoniq
-      - title: ActionScript
-        modal: as
-        packages:
-          - title: linter-flexpmd
-            url: https://atom.io/packages/linter-flexpmd
-      - title: Flash
-        modal: swf
-        packages:
-          - title: linter-flexpmd
-            url: https://atom.io/packages/linter-flexpmd
-      - title: Flex
-        modal: flex
-        packages:
-          - title: linter-flexpmd
-            url: https://atom.io/packages/linter-flexpmd
-      - title: AIR
-        modal: air
-        packages:
-          - title: linter-flexpmd
-            url: https://atom.io/packages/linter-flexpmd
       - title: Swift
         modal: swift
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -190,8 +190,6 @@ linters:
         packages:
           - title: linter-clang
             url: https://atom.io/packages/linter-clang
-          - title: linter-cpplint
-            url: https://atom.io/packages/linter-cpplint
           - title: linter-gcc
             url: https://atom.io/packages/linter-gcc
           - title: linter-moose

--- a/_config.yml
+++ b/_config.yml
@@ -260,11 +260,6 @@ linters:
         packages:
           - title: linter-squirrel
             url: https://atom.io/packages/linter-squirrel
-      - title: CoDScript
-        modal: cod
-        packages:
-          - title: linter-codscript
-            url: https://atom.io/packages/linter-codscript
       - title: harbour
         modal: harbour
         packages:

--- a/_config.yml
+++ b/_config.yml
@@ -34,8 +34,6 @@ linters:
             url: https://atom.io/packages/linter-eslint
           - title: linter-flow
             url: https://atom.io/packages/linter-flow
-          - title: linter-flow-plus
-            url: https://atom.io/packages/linter-flow-plus
           - title: linter-js-standard
             url: https://atom.io/packages/linter-js-standard
           - title: linter-xo

--- a/_config.yml
+++ b/_config.yml
@@ -79,11 +79,6 @@ linters:
             url: https://atom.io/packages/linter-reek
           - title: linter-ruby-reek
             url: https://atom.io/packages/linter-ruby-reek
-      - title: ERB
-        modal: erb
-        packages:
-          - title: linter-erb
-            url: https://atom.io/packages/linter-erb
       - title: Haml
         modal: haml
         packages:


### PR DESCRIPTION
All removed linters may be readded when they are updated to the new Linter API.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/10)
<!-- Reviewable:end -->
