### PR TITLE
Add linter-MATLAB

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -324,6 +324,11 @@ linters:
         packages:
           - title: linter-moonscript
             url: https://atom.io/packages/linter-moonscript
+      - title: MATLAB
+        modal: matlab
+        packages:
+          - title: linter-matlab
+            url: https://atom.io/packages/linter-matlab
   - ides:
     title: Integrated Devlopment Environments
     plural: IDEs


### PR DESCRIPTION
Adds a link to the MATLAB mlint-based linter, [linter-matlab](https://atom.io/packages/linter-matlab).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/12)
<!-- Reviewable:end -->
