### PR TITLE
Add back linter-gjslint

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,8 @@ linters:
             url: https://atom.io/packages/linter-marlint
           - title: linter-liferay
             url: https://atom.io/packages/linter-liferay
+          - title: linter-gjslint
+            url: https://atom.io/packages/linter-gjslint
       - title: CoffeeScript
         modal: coffee
         packages:


### PR DESCRIPTION
It now supports the new Linter APIs - so it's working again :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/13)
<!-- Reviewable:end -->
