### PR TITLE
Add linter-sass-lint to linter list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -123,6 +123,8 @@ linters:
             url: https://atom.io/packages/linter-scss-lint
           - title: linter-9e-sass
             url: https://atom.io/packages/linter-9e-sass
+          - title: linter-sass-lint
+            url: https://atom.io/packages/linter-sass-lint
       - title: SCSS
         modal: scss
         packages:
@@ -130,6 +132,8 @@ linters:
             url: https://atom.io/packages/linter-scss-lint
           - title: linter-liferay
             url: https://atom.io/packages/linter-liferay
+          - title: linter-sass-lint
+            url: https://atom.io/packages/linter-sass-lint
       - title: less
         modal: less
         packages:


### PR DESCRIPTION
I'd like to have my linter plugin added to the list of linters if that's ok, hopefully this is the right way to go about it!

Adds linter-sass-lint plugin to the Sass and SCSS format lists.

Atom package page can be found [here](https://atom.io/packages/linter-sass-lint)
Repo can be found [here](https://github.com/DanPurdy/linter-sass-lint)

Thanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/15)
<!-- Reviewable:end -->
