### PR TITLE
add linter for GitHub Pull Request comments

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -402,3 +402,8 @@
       packages:
         - title: linter-manager
           url: https://atom.io/packages/linter-manager
+    - title: GitHub
+      modal: github
+      packages:
+        - title: pull-requests
+          url: https://atom.io/packages/pull-requests


### PR DESCRIPTION
Originally in https://github.com/atom-community/linter/pull/1012.

Should I just use the package name in the title?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/20)
<!-- Reviewable:end -->
