### PR TITLE
Add linter-mixed-indent to providers file

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -24,6 +24,8 @@
           url: https://atom.io/packages/linter-liferay
         - title: linter-gjslint
           url: https://atom.io/packages/linter-gjslint
+        - title: linter-mixed-indent
+          url: https://atom.io/packages/linter-mixed-indent
     - title: CoffeeScript
       modal: coffee
       packages:
@@ -96,6 +98,8 @@
           url: https://atom.io/packages/linter-csslint
         - title: linter-liferay
           url: https://atom.io/packages/linter-liferay
+        - title: linter-mixed-indent
+          url: https://atom.io/packages/linter-mixed-indent
     - title: R
       modal: r
       packages:
@@ -110,6 +114,8 @@
           url: https://atom.io/packages/linter-9e-sass
         - title: linter-sass-lint
           url: https://atom.io/packages/linter-sass-lint
+        - title: linter-mixed-indent
+          url: https://atom.io/packages/linter-mixed-indent
     - title: SCSS
       modal: scss
       packages:
@@ -119,6 +125,8 @@
           url: https://atom.io/packages/linter-liferay
         - title: linter-sass-lint
           url: https://atom.io/packages/linter-sass-lint
+        - title: linter-mixed-indent
+          url: https://atom.io/packages/linter-mixed-indent
     - title: less
       modal: less
       packages:

--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -24,8 +24,6 @@
           url: https://atom.io/packages/linter-liferay
         - title: linter-gjslint
           url: https://atom.io/packages/linter-gjslint
-        - title: linter-mixed-indent
-          url: https://atom.io/packages/linter-mixed-indent
     - title: CoffeeScript
       modal: coffee
       packages:
@@ -98,8 +96,6 @@
           url: https://atom.io/packages/linter-csslint
         - title: linter-liferay
           url: https://atom.io/packages/linter-liferay
-        - title: linter-mixed-indent
-          url: https://atom.io/packages/linter-mixed-indent
     - title: R
       modal: r
       packages:
@@ -114,8 +110,6 @@
           url: https://atom.io/packages/linter-9e-sass
         - title: linter-sass-lint
           url: https://atom.io/packages/linter-sass-lint
-        - title: linter-mixed-indent
-          url: https://atom.io/packages/linter-mixed-indent
     - title: SCSS
       modal: scss
       packages:
@@ -125,8 +119,6 @@
           url: https://atom.io/packages/linter-liferay
         - title: linter-sass-lint
           url: https://atom.io/packages/linter-sass-lint
-        - title: linter-mixed-indent
-          url: https://atom.io/packages/linter-mixed-indent
     - title: less
       modal: less
       packages:
@@ -395,6 +387,11 @@
       packages:
         - title: linter-scspell
           url: https://atom.io/packages/linter-scspell
+    - title: Style
+      modal: style
+      packages:
+        - title: linter-mixed-indent
+          url: https://atom.io/packages/linter-mixed-indent
 - plugin:
   title: Linter Plugins
   plural: Plugins


### PR DESCRIPTION
Added under JavaScript, CSS, sass, and scss because those are the filetypes I have mostly used, but it could theoretically be under `generic`, since it does operate on all filetypes at the moment.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/21)
<!-- Reviewable:end -->
