### PR TITLE
Revert "add linter-swift-package-manager"

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -245,8 +245,6 @@
           url: https://atom.io/packages/linter-swiftc
         - title: linter-swiftlint
           url: https://atom.io/packages/linter-swiftlint
-        - title: linter-swift-package-manager
-          url: https://github.com/pk11/linter-swift-package-manager
     - title: LaTeX
       modal: latex
       packages:


### PR DESCRIPTION
Reverts AtomLinter/atomlinter.github.io#26

Link was to the GitHub repo, and the package doesn't appear to currently be published on apm.

Silly me for not checking in the first place!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/27)
<!-- Reviewable:end -->
