### PR TITLE
Add linter-erb

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -57,6 +57,13 @@
           url: https://atom.io/packages/linter-reek
         - title: linter-ruby-reek
           url: https://atom.io/packages/linter-ruby-reek
+        - title: linter-erb
+          url: https://atom.io/packages/linter-erb
+    - title: Embedded Ruby
+      modal: erb
+      packages:
+        - title: linter-erb
+          url: https://atom.io/packages/linter-erb
     - title: Haml
       modal: haml
       packages:


### PR DESCRIPTION
Add back linter-erb now that it has been re-written.

Should this go under the Ruby section like this, or under a new ERB section? It's just templatized Ruby, but it does have a different file extension so it might need a different modal?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/29)
<!-- Reviewable:end -->
