### PR TITLE
linter-pep257 renamed to linter-pydocstyle

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -87,8 +87,8 @@
           url: https://atom.io/packages/linter-pylint
         - title: linter-pep8
           url: https://atom.io/packages/linter-pep8
-        - title: linter-pep257
-          url: https://atom.io/packages/linter-pep257
+        - title: linter-pydocstyle
+          url: https://atom.io/packages/linter-pydocstyle
         - title: linter-flake8
           url: https://atom.io/packages/linter-flake8
         - title: linter-pylama


### PR DESCRIPTION
Fix https://github.com/AtomLinter/linter-pydocstyle/issues/51

Background: https://github.com/AtomLinter/linter-pydocstyle/issues/31

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/40)
<!-- Reviewable:end -->
