### PR TITLE
Revert "Redesign for linter section"

### DIFF
--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -1,36 +1,17 @@
+.img-centered {
+    margin: 0 auto;
+}
+
 div .header {
-  text-align: center;
-  color: #{{ site.color.secondary }};
-  background: #{{ site.color.primary }};
+    text-align: center;
+    color: #{{ site.color.secondary }};
+    background: #{{ site.color.primary }};
 }
 
 div .navbar {
   background: #{{ site.color.secondary }};
 }
 
-.navbar a:hover {
+a:hover {
   background-color: #{{ site.color.active }};
-}
-
-.packages {
-  list-style: none;
-  padding-left: .6em;
-}
-
-.packages li {
-  font-size: 16px;
-  line-height: 2.2;
-}
-
-.packages a {
-  color: #{{ site.color.secondary }};
-  text-decoration: none;
-  padding: .5em .6em;
-  -webkit-transition: all .1s;
-  -o-transition: all .1s;
-  transition: all .1s;
-}
-
-.packages a:hover {
-  background: #F0F0F0;
 }

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,9 +10,9 @@
     <link rel="stylesheet" href="style.css">
 
     <!-- Google Material Design Lite. Gotta have those cards. -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Roboto|Material+Icons">
-    <link rel="stylesheet" href="https://code.getmdl.io/1.1.3/material.indigo-pink.min.css">
-    <script defer src="https://code.getmdl.io/1.1.3/material.min.js"></script>
+    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.indigo-pink.min.css">
+    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/_includes/providers.html
+++ b/_includes/providers.html
@@ -1,25 +1,20 @@
-<div class="mdl-grid">
-  {% for scope in site.data.providers %}
-  <div id="{{ scope.modal }}" class="mdl-cell mdl-cell--2-offset mdl-cell--8-col">
+{% for scope in site.data.providers %}
+<div id="{{ scope.modal }}">
     <h2>{{ scope.title }}</h2>
-    <!-- <hr> -->
     <div class="mdl-grid">
       {% assign types = scope.types | sort: 'title' %}
       {% for type in types %}
-      <div class="mdl-cell mdl-cell--4-col mdl-card mdl-shadow--2dp">
-        <div class="mdl-card__title">
-          <h3 class="mdl-card__title-text">{{ type.title }}</h3>
+        <div class="mdl-card mdl-cell mdl-cell--4-col mdl-cell--4-col-tablet mdl-shadow--2dp" id="{{ scope.modal }}-{{ type.modal }}">
+          <div class="mdl-card__title">
+            <h2 class="mdl-card__title-text">{{ type.title }}</h2>
+          </div>
+          {% for package in type.packages %}
+          <div class="mdl-card__actions mdl-card--border">
+              <a class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect" href="{{ package.url }}">{{ package.title }}</a>
+          </div>
+          {% endfor %}
         </div>
-        <div class="mdl-card__actions mdl-card--border">
-          <ul class="packages">
-            {% for package in type.packages %}
-            <li><a href="{{ package.url }}">{{ package.title }}</a></li>
-            {% endfor %}
-          </ul>
-        </div>
-      </div>
       {% endfor %}
     </div>
-  </div>
-  {% endfor %}
 </div>
+{% endfor %}


### PR DESCRIPTION
Reverts AtomLinter/atomlinter.github.io#46

This release had some spacing issues I'd rather not ship.

When viewed in smaller viewports the page content aligns awkwardly to the right of the screen.

Tablet-Like Viewport
![screen shot 2016-03-29 at 9 48 04 am](https://cloud.githubusercontent.com/assets/594124/14114257/884c8206-f593-11e5-8294-7e67814d94b1.png)

Phone-Like Viewport
![screen shot 2016-03-29 at 9 47 46 am](https://cloud.githubusercontent.com/assets/594124/14114283/9f4fcec2-f593-11e5-9d37-36c5473341a6.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/48)
<!-- Reviewable:end -->
