### PR TITLE
removing linter-puppet-parse

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -217,8 +217,6 @@
       packages:
         - title: linter-puppet-lint
           url: https://atom.io/packages/linter-puppet-lint
-        - title: linter-puppet-parse
-          url: https://atom.io/packages/linter-puppet-parse
         - title: linter-puppet-parser
           url: https://atom.io/packages/linter-puppet-parser
         - title: linter-puppet-parsing


### PR DESCRIPTION
removing broken linter-puppet-parse as per discussion in #41

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/55)
<!-- Reviewable:end -->
