### PR TITLE
Remove "linter-jade" from providers list

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -304,11 +304,6 @@
           url: https://atom.io/packages/linter-handlebars
         - title: linter-liferay
           url: https://atom.io/packages/linter-liferay
-    - title: Jade
-      modal: jade
-      packages:
-        - title: linter-jade
-          url: https://atom.io/packages/linter-jade
     - title: Jolie
       modal: jolie
       packages:


### PR DESCRIPTION
It looks like @zyklus removed the repo and it currently errors if you attempt to install:

`Unable to download https://www.atom.io/api/packages/linter-jade/versions/0.3.2/tarball: 400 Bad Request Repository inaccessible`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/56)
<!-- Reviewable:end -->
