### PR TITLE
Add linter-cookstyle to list of linters

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -410,7 +410,7 @@
       modal: chef
       packages:
         - title: linter-cookstyle
-        url: https://atom.io/packages/linter-cookstyle
+          url: https://atom.io/packages/linter-cookstyle
 - ides:
   title: Integrated Development Environments
   plural: IDEs

--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -409,7 +409,7 @@
     - title: Chef
       modal: chef
       packages:
-        - title linter-cookstyle
+        - title: linter-cookstyle
         url: https://atom.io/packages/linter-cookstyle
 - ides:
   title: Integrated Development Environments

--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -406,6 +406,11 @@
       packages:
         - title: linter-icinga-validate
           url: https://atom.io/packages/linter-icinga-validate
+    - title: Chef
+      modal: chef
+      packages:
+        - title linter-cookstyle
+        url: https://atom.io/packages/linter-cookstyle
 - ides:
   title: Integrated Development Environments
   plural: IDEs


### PR DESCRIPTION
Cookstyle is a linter for Chef infracode; this linter uses the cookstyle linter in Atom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/atomlinter.github.io/60)
<!-- Reviewable:end -->
