### PR TITLE
Update providers.yml (add linter-american)

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -515,6 +515,8 @@
           url: https://atom.io/packages/linter-proselint
         - title: linter-ibmstyleguide
           url: https://atom.io/packages/linter-ibmstyleguide
+        - title: linter-american
+          url: https://atom.io/packages/linter-american
     - title: Spell Checking
       modal: spelling
       packages:


### PR DESCRIPTION
Add `linter-american`. Linter to make American spelling great again.