### PR TITLE
Update providers.yml (add linter-rust-cargo)

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -258,6 +258,8 @@
       packages:
         - title: linter-rust
           url: https://atom.io/packages/linter-rust
+        - title: linter-rust-cargo
+          url: https://atom.io/packages/linter-rust-cargo
     - title: Elixir
       modal: elixir
       packages:


### PR DESCRIPTION
Add `linter-rust-cargo`. A fast alternative to `linter-rust`.