### PR TITLE
Added linter-google-styleguide

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -526,6 +526,8 @@
           url: https://atom.io/packages/linter-ibmstyleguide
         - title: linter-american
           url: https://atom.io/packages/linter-american
+        - title: linter-google-styleguide
+          url: https://atom.io/packages/linter-google-styleguide
     - title: Spell Checking
       modal: spelling
       packages:


### PR DESCRIPTION
Added [Linter Google Styleguide](https://atom.io/packages/linter-google-styleguide) to the list.