### PR TITLE
Add linter-coverage

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -511,6 +511,11 @@
       packages:
         - title: linter-flint
           url: https://atom.io/packages/linter-flint
+    - title: Code Quality
+      modal: quality
+      packages:
+        - title: linter-coverage
+          url: https://atom.io/packages/linter-coverage
     - title: Writing Assistance
       modal: writing
       packages:


### PR DESCRIPTION
Hello! I would like to add my new [linter-coverage](https://atom.io/packages/linter-coverage) to the list.

Since the coverage report can be used in many languages, I created a new section under _Generic Linters_. Let me know if you would like to move it elsewhere.

Thanks! 🍻