### PR TITLE
Add linter-dryer

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -589,6 +589,8 @@
       packages:
         - title: linter-coverage
           url: https://atom.io/packages/linter-coverage
+        - title: linter-dryer
+          url: https://atom.io/packages/linter-dryer
     - title: Writing Assistance
       modal: writing
       packages:


### PR DESCRIPTION
Add [`linter-dryer`](https://atom.io/packages/linter-dryer) to the providers data.

`linter-dryer` looks for code duplication so I’ve added it under “Code Quality,” but perhaps there’s a better place?