### PR TITLE
Add IDE-Mocha ☕️

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -522,6 +522,8 @@
           url: https://atom.io/packages/ide-flowtype
         - title: ide-typescript
           url: https://atom.io/packages/ide-typescript
+        - title: ide-mocha
+          url: https://atom.io/packages/ide-mocha
     - title: OCaml
       modal: ml
       packages:


### PR DESCRIPTION
Here is a gif of the [package](https://atom.io/packages/ide-mocha) in action. It streams Mocha's test suite progress to Atom via a socket and then Atom processes that information to show the progress logs and diagnostic messages to the user via the Atom-IDE-UI component suite.

![IDE-Mocha demo](
https://i.github-camo.com/a0b9f67b637aeb7d74488187d6d9f9143bdbed01/68747470733a2f2f757365722d696d616765732e67697468756275736572636f6e74656e742e636f6d2f333035383135302f34383330373633322d33326162353130302d653535312d313165382d393064382d3864633138383931643436632e676966)