### PR TITLE
Added linter-glualint

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -216,6 +216,8 @@
           url: https://atom.io/packages/linter-lua-findglobals
         - title: linter-glua
           url: https://atom.io/packages/linter-glua
+        - title: linter-glualint
+          url: https://atom.io/packages/linter-glualint
         - title: linter-luaparse
           url: https://atom.io/packages/linter-luaparse
     - title: Clojure


### PR DESCRIPTION
Linter-glualint is the Atom linter package for my own `glualint` package. It's designed for the specific flavour of Lua used by Garry's mod, though it should work with regular Lua, as GMod merely extended the language.

It has existed for a while, but I updated it for the latest provider recently.