### PR TITLE
Limit gatsby updates to weekly

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,17 @@
   "renovate": {
     "extends": [
       "config:base"
+    ],
+    "packageRules": [
+      {
+        "packagePatterns": [
+          "^gatsby"
+        ],
+        "groupName": "Gatsby packages",
+        "extends": [
+          "schedule:weekly"
+        ]
+      }
     ]
   },
   "dependencies": {


### PR DESCRIPTION
The gatsby team publishes many releases for things that have no bearing on the code such as blog posts, and seems to make minute changes many times a day.

Tell Renovate to only update this package and the related packages once a week.