### PR TITLE
Add python-linters

### DIFF
--- a/content/data/providers.yml
+++ b/content/data/providers.yml
@@ -96,6 +96,8 @@
     - title: Python
       modal: py
       packages:
+        - title: python-linters
+          url: https://atom.io/packages/python-linters
         - title: linter-pylint
           url: https://atom.io/packages/linter-pylint
         - title: linter-pep8


### PR DESCRIPTION
python-linters is a python linter which wrap multi lint tool, currently : (flake8, mypy, pydocstyle, pylint) into a single atom package