### PR TITLE
Add stylelint

### DIFF
--- a/content/data/providers.yml
+++ b/content/data/providers.yml
@@ -140,6 +140,8 @@
           url: https://atom.io/packages/linter-9e-sass
         - title: linter-sass-lint
           url: https://atom.io/packages/linter-sass-lint
+        - title: linter-stylelint
+          url: https://atom.io/packages/linter-stylelint
     - title: SCSS
       modal: scss
       packages:
@@ -149,11 +151,15 @@
           url: https://atom.io/packages/linter-liferay
         - title: linter-sass-lint
           url: https://atom.io/packages/linter-sass-lint
+        - title: linter-stylelint
+          url: https://atom.io/packages/linter-stylelint
     - title: less
       modal: less
       packages:
         - title: linter-less
           url: https://atom.io/packages/linter-less
+        - title: linter-stylelint
+          url: https://atom.io/packages/linter-stylelint
     - title: stylus
       modal: stylus
       packages:


### PR DESCRIPTION
Added linter-stylelint to SCSS, SASS, Less sections, because it supports linting those files as well as regular CSS. I believe it is a better option than those already listed. It also performs better, at least for me.