### PR TITLE
Added verilog language and linter-veriloghdl

### DIFF
--- a/content/data/providers.yml
+++ b/content/data/providers.yml
@@ -508,6 +508,11 @@
       packages:
         - title: linter-vault-policy
           url: https://atom.io/packages/linter-vault-policy
+    - title: Verilog
+      modal: verilog
+      packages:
+        - title: linter-veriloghdl
+          url: https://atom.io/packages/linter-veriloghdl
 - ides:
   title: Integrated Development Environments
   plural: IDEs


### PR DESCRIPTION
Hello! I've recently put together this package for linting Verilog/SystemVerilog. May I add it to the list of linters? I noticed that currently there is no entry for the Verilog language. If this is reasonable to add, is there anything besides what I have added that needs to be done to put an additional language on the webpage? Thanks!