### PR TITLE
Add linter-gccgo

### DIFF
--- a/content/data/providers.yml
+++ b/content/data/providers.yml
@@ -320,6 +320,8 @@
           url: https://atom.io/packages/linter-revive
         - title: linter-govet
           url: https://atom.io/packages/linter-govet
+        - title: linter-gccgo
+          url: https://atom.io/packages/linter-gccgo
     - title: JSON
       modal: json
       packages:


### PR DESCRIPTION
I have the source at https://github.com/ItzSwirlz/linter-gccgo - I was hoping that maybe it could get pushed into this organization, and then have whoever is in charge of the AtomLinter account on APM to upload it, and then this could be merged.

GCC Go is part of the GNU Compiler Collection as a Golang frontend.